### PR TITLE
level id entity map refactor

### DIFF
--- a/src/engine/level.cpp
+++ b/src/engine/level.cpp
@@ -1,5 +1,6 @@
 #include "level.h"
 #include "debug_log_interface.h"
+#include "events.h"
 #include <raymath.h>
 namespace{
     std::string vector_to_string(Vector2 position){
@@ -61,7 +62,7 @@ void level::level::add_entity(std::unique_ptr<entities::entity> entity, size_t l
     level_entities_.insert(std::move(entity));
     // insert into the draw layer ?
     render_layers_[layer].add_entity(entity_raw);
-    id_entity_map_[static_cast<int>(entity_id)] = entity_raw;
+    id_entity_map_[static_cast<size_t>(entity_id)] = entity_raw;
     next_entity_id_ = std::max(next_entity_id_, entity_id + 1);
 
     if(table != nullptr){
@@ -192,6 +193,7 @@ void level::level::insert_void_entity(void_entity_record record){
 int level::level::entity_id(){
     return next_entity_id_;
 }
+
 int level::level::num_entities(){
     return static_cast<int>(level_entities_.size());
 }
@@ -275,7 +277,15 @@ void level::level::on_send_dog_to_furniture(const events::send_dog_to_furniture&
 
     dog->set_path(path, static_cast<int>(event.get_furniture_id()), event.get_furniture_position());
 }
-
+void level::level::on_removed_entity(const events::remove_entity& event){
+    // TODO: implement
+    // take over the quadtree remove
+    // and remove from the map 
+    // then write a test
+    size_t id = event.get_id();
+    level_entities_.erase(id);
+    id_entity_map_.erase(id);
+}
 void level::level::on_order_served_event(const events::order_served& event){
     auto customer_id = static_cast<int>(event.get_customer_id());
     auto customer_record = id_entity_map_.find(customer_id);

--- a/src/engine/level.h
+++ b/src/engine/level.h
@@ -14,12 +14,14 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <queue>
 #include <utility>
 #include <vector>
 
 #include "config.h"
+#include "events.h"
 #include "quadtree.h"
 #include "queries.h"
 #include "query_interface.h"
@@ -142,6 +144,7 @@ namespace level{
 		            event_interface::unsubscribe<events::send_dog_to_position>(send_dog_to_position_handler_);
 		            event_interface::unsubscribe<events::send_dog_to_furniture>(send_dog_to_furniture_handler_);
 		            event_interface::unsubscribe<events::order_served>(order_served_handler_);
+		            event_interface::unsubscribe<events::remove_entity>(removed_entity_handler_);
 		            }
             level(sprite::sprite sprite, Rectangle frame, Vector2 dimensions)
             : left_mouse_click_handler_([this](const events::left_mouse_click& event) -> void{on_left_mouse_click_event(event);}),
@@ -151,6 +154,7 @@ namespace level{
 		            send_dog_to_position_handler_([this](const events::send_dog_to_position& event) -> void{on_send_dog_to_position_event(event);}),
 		            send_dog_to_furniture_handler_([this](const events::send_dog_to_furniture& event) -> void{on_send_dog_to_furniture(event);}),
 		            order_served_handler_([this](const events::order_served& event) -> void{on_order_served_event(event);}),
+		            removed_entity_handler_([this](const events::remove_entity& event) -> void{on_removed_entity(event);}),
 		            graph_(level_graph(static_cast<int>(dimensions.x), static_cast<int>(dimensions.y))),
             view_frame_(frame), background_(sprite), id_entity_map_({}),
             next_entity_id_(0),
@@ -163,6 +167,7 @@ namespace level{
 		                event_interface::subscribe<events::send_dog_to_position>(send_dog_to_position_handler_);
 		                event_interface::subscribe<events::send_dog_to_furniture>(send_dog_to_furniture_handler_);
 		                event_interface::subscribe<events::order_served>(order_served_handler_);
+		                event_interface::subscribe<events::remove_entity>(removed_entity_handler_);
 		            }
             level(const level& other) = delete;
             level(level&& other) = delete;
@@ -180,11 +185,11 @@ namespace level{
             void on_move_view_frame_event(const events::move_view_frame& event);
             void on_right_mouse_event(const events::right_mouse_click& event);
 
-		            void on_build_customer_dog_event(const events::build_customer_dog& event);
-		            void on_send_dog_to_position_event(const events::send_dog_to_position& event);
-		            void on_send_dog_to_furniture(const events::send_dog_to_furniture& event);
-		            void on_order_served_event(const events::order_served& event);
-            
+		    void on_build_customer_dog_event(const events::build_customer_dog& event);
+		    void on_send_dog_to_position_event(const events::send_dog_to_position& event);
+            void on_order_served_event(const events::order_served& event);
+		    void on_send_dog_to_furniture(const events::send_dog_to_furniture& event);
+            void on_removed_entity(const events::remove_entity& event);
             void render(int frame);
             void update(float delta, int frame);
         private :
@@ -204,18 +209,18 @@ namespace level{
             events::event_handler<events::move_view_frame> move_view_frame_handler_;
             events::event_handler<events::right_mouse_click> right_mouse_click_handler_;
 
-
 		    events::event_handler<events::build_customer_dog> build_customer_dog_handler_;
 		    events::event_handler<events::send_dog_to_position> send_dog_to_position_handler_;
 		    events::event_handler<events::send_dog_to_furniture> send_dog_to_furniture_handler_;
 		    events::event_handler<events::order_served> order_served_handler_;
 
+            events::event_handler<events::remove_entity> removed_entity_handler_;
             
             level_graph graph_;
             
             Rectangle view_frame_;
             sprite::sprite background_;
-            std::map<int, entities::entity*> id_entity_map_;
+            std::unordered_map<size_t, entities::entity*> id_entity_map_;
             render_layer::layer render_layers_[level_config::size];
             int next_entity_id_;
             tree::quadtree level_entities_;

--- a/src/engine/quadtree.h
+++ b/src/engine/quadtree.h
@@ -46,7 +46,6 @@ namespace tree{
     private:
         // event and query handlers 
         events::event_handler<events::move_entity> moved_entity_handler_;
-        events::event_handler<events::remove_entity> removed_entity_handler_;
         events::event_handler<events::interact_entity> interact_entity_handler_;
         
         queries::query_handler<queries::is_colliding_query, bool> is_colliding_handler_;
@@ -92,13 +91,11 @@ namespace tree{
         ~quadtree() {
             event_interface::unsubscribe<events::interact_entity>(interact_entity_handler_);
             event_interface::unsubscribe<events::move_entity>(moved_entity_handler_);
-            event_interface::unsubscribe<events::remove_entity>(removed_entity_handler_);
             query_interface::unsubscribe<queries::is_colliding_query, bool>(queries::bool_executor_, is_colliding_handler_);
         }
         // creates an empty quadtree with a root node
         quadtree(raglib::bounding_box_2 root_bounds, int depth=MAX_DEPTH)
         : moved_entity_handler_([this](const events::move_entity& event) -> void {on_move_event(event);}), 
-        removed_entity_handler_([this](const events::remove_entity& event) -> void {on_remove_event(event);}),
         interact_entity_handler_([this](const events::interact_entity& event) -> void {on_interact_event(event);}), 
         is_colliding_handler_([this](const queries::is_colliding_query& query) -> bool {return on_is_colliding_query(query);}),
         max_depth_(depth), next_ids_(), next_id_(0), root_(std::make_unique<node>()) {
@@ -109,7 +106,6 @@ namespace tree{
             // sub 
             event_interface::subscribe<events::interact_entity>(interact_entity_handler_);
             event_interface::subscribe<events::move_entity>(moved_entity_handler_);
-            event_interface::subscribe<events::remove_entity>(removed_entity_handler_);
             query_interface::subscribe<queries::is_colliding_query, bool>(queries::bool_executor_, is_colliding_handler_);
         }
         // creates an empty quadtree, then populates it with the list of objects
@@ -128,14 +124,12 @@ namespace tree{
         // copy and move overloads, root, depth and next id
         quadtree(const quadtree& other)
         : moved_entity_handler_(other.moved_entity_handler_), 
-        removed_entity_handler_(other.removed_entity_handler_),
         interact_entity_handler_(other.interact_entity_handler_), 
         is_colliding_handler_(other.is_colliding_handler_),
         max_depth_(other.max_depth_), next_ids_(other.next_ids_), next_id_(other.next_id_){
             root_ = copy_tree(other.root_.get(), nullptr);
             event_interface::subscribe<events::interact_entity>(interact_entity_handler_);
             event_interface::subscribe<events::move_entity>(moved_entity_handler_);
-            event_interface::subscribe<events::remove_entity>(removed_entity_handler_);
             query_interface::subscribe<queries::is_colliding_query, bool>(queries::bool_executor_, is_colliding_handler_);
 
             // and resub
@@ -239,12 +233,6 @@ namespace tree{
             auto entity = extract(root_, id);
             insert(root_, std::move(entity));
         }
-        void on_remove_event(const events::remove_entity& event){
-            size_t id = event.get_id();
-            erase(id);
-        }
-
-
         void prune_leaves(double delta) {
             prune_leaves(root_, delta);
         }

--- a/tests/decoration_scenarios.cpp
+++ b/tests/decoration_scenarios.cpp
@@ -5,6 +5,8 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "test_game.h"
+#include "events.h"
+#include "events_interface.h"
 
 using testing::test_game;
 
@@ -32,6 +34,33 @@ SCENARIO("a food counter is built and inserted into the level", "[decoration][st
             game.insert_entity(game.build_food_counter(counter_id, position), level_config::draw_layers::stations);
             THEN("the level contains a food counter with that id"){
                 REQUIRE(game.find_entity(counter_id) != nullptr);
+            }
+        }
+    }
+}
+
+SCENARIO("a decoration is removed from the level via remove_entity event",
+        "[decoration][station][remove]"){
+    GIVEN("a fresh game with a table inserted"){
+        test_game game;
+        const int table_id = 202;
+        const Vector2 position{level_config::edge_weight * 12, level_config::edge_weight * 12};
+
+        const int baseline_count = game.num_entities();
+        game.insert_entity(game.build_table(table_id, position),
+                           level_config::draw_layers::stations);
+
+        // Pre-condition: table is present and count grew by exactly 1.
+        REQUIRE(game.num_entities() == baseline_count + 1);
+        REQUIRE(game.find_entity(table_id) != nullptr);
+
+        WHEN("a remove_entity event is executed for the table"){
+            events::remove_entity remove{static_cast<size_t>(table_id)};
+            event_interface::execute_event(remove);
+
+            THEN("the count returns to baseline and the table is no longer found"){
+                REQUIRE(game.num_entities() == baseline_count);
+                REQUIRE(game.find_entity(table_id) == nullptr);
             }
         }
     }


### PR DESCRIPTION
- switch from ordered map to unordered map for more performant lookup given the key is just an int
- level now handles the remove entity event listening as opposed to the quadtree so it can manage the map and the quadtree 
- added unit test to check correctness