### PR TITLE
Ecs counters and waiters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ link_libraries(events)
 
 add_library(queries src/engine/queries/queries.cpp)
 link_libraries(queries)
+add_library(item_stack src/engine/structures/item_stack.cpp)
 add_library(factories
             src/entities/factories/dog_factory.cpp
             src/entities/factories/station_factory.cpp)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # a-dogs-day
-an idle cafe game themed aroung my dogs
+an 2D dog-themed cafe simulator game 
+
+## state of play
+### complete
+- customer queuing and arrival
+- player dog control
+- cameara navigation 
+- decoration and station building, rendering and selection
+### in progress
+- station construction and interactions
+- food storage
+- waiter construction and control
+## near future
+- food preparation
+- menus and hud
+- shop and level arrangement
+- inventory management and economy
+## further down the line
+- dog cosmetics
+- fully fledged animations
+- save files
+
+## technology framework
+written in C++ using raylib as a basic graphics library
+
+other components of the engine designed and developed by me. structures of note include 
+- quad tree spatial partitioning for collision and interaction detection
+- entity component system
+- view frame render culling 
+- typed interaction handling [in progress]
+- 9-slicing sprites [todo]
+
+
+### ai usage
+claude used an assitive tool to discuss designs, data strucutres, documentation and general approaches, but the final code is wrtten by hand
+
+all art is original and handmade
+
+### dog submissions
+this game is a love letter to dogs. If you want me to add your dog to the game raise an issue in this repository using the template !

--- a/logs/8-26.txt
+++ b/logs/8-26.txt
@@ -484,8 +484,19 @@ raw position paths [picks up the note at line 323 above]
 
 26 / 8 - Serving System 
 pre-requsities:
--> counter building and destroying
+-> counter building and destroying x 
 -> food [as an item stored by the counter and as an entity carried by a waiter]
+   -> storing food on a counter through a storage component
+   -> food is stored as a list of entity ids,[ should not be entity ids, should be food ids instead]
+      -> or if we are keeping the rule of one type of food per counter then 
+      -> the coutner can just store the food_id it maintains, and then the number,
+      -> then we just render that one on top
+         -> even still, we dont have to restrict to just one food item per order, can define a struct {food, amount},
+         -> and then just render the top most struct, [it is the one that is given the positional and the renderable]
+         -> taking an itme removes a count of that structur, removing the final item pops the struct
+   -> perhaps we can register / unregister components on change of the head of the stack
+      -> so when popped it creates the food item as an entity then builds the positional and renderable component for the item on the top of the stack
+      -> when pushed the current head is un registered and the newly pushed one is registered
 -> counter storage of food
 -> waiter building and destroying
 -> interaction detection [x], creation and processing

--- a/logs/8-26.txt
+++ b/logs/8-26.txt
@@ -497,9 +497,25 @@ pre-requsities:
    -> perhaps we can register / unregister components on change of the head of the stack
       -> so when popped it creates the food item as an entity then builds the positional and renderable component for the item on the top of the stack
       -> when pushed the current head is un registered and the newly pushed one is registered
--> counter storage of food
+-> counter storage of food x
+   -> define the item enums, the sprite builders
+   -> the compoennts for the head of the stack so it can render at a position 
 -> waiter building and destroying
--> interaction detection [x], creation and processing
+   -> same setup of the enum, the builders [in the dog facotyr]
+   -> waiter state machine [at least idling for now]
+   -> waiter selection and path sending like player dogs
+
+-> then items as entities
+   -> item factory and item builders
+   -> they should exist as entities when being carried by a waiter and when on a table 
+-> interaction detection [x], 
+   -> creation and processing, this is the big? one
+   -> on interaction (interactor id, interactable id) 
+      -> create an interaction object - explore this concept
+      -> store a list of interaction objects that list interactor types and interactee types
+      -> then when detecting an interaction you check the interactions that the interactor is a type of and the 
+      interactee is a type of
+      -> so we need like a type component or a handle as the video suggets
 
 
 -> when a customer sits at a table they make a request [they transition to a waiting state], and waits for up to 2 minutes

--- a/logs/8-26.txt
+++ b/logs/8-26.txt
@@ -497,6 +497,7 @@ pre-requsities:
    -> perhaps we can register / unregister components on change of the head of the stack
       -> so when popped it creates the food item as an entity then builds the positional and renderable component for the item on the top of the stack
       -> when pushed the current head is un registered and the newly pushed one is registered
+// * -------------------- HERE 28 / 8 ------------------- * //
 -> counter storage of food x
    -> define the item enums, the sprite builders
    -> the compoennts for the head of the stack so it can render at a position 

--- a/logs/8-26.txt
+++ b/logs/8-26.txt
@@ -479,3 +479,42 @@ raw position paths [picks up the note at line 323 above]
    dog cannot step over the target between frames
 -> open: the graph occupancy marks whole nodes. two dogs a quarter edge apart inside one node
    would both mark it, and the second would read the first as blocking
+
+
+
+26 / 8 - Serving System 
+pre-requsities:
+-> counter building and destroying
+-> food [as an item stored by the counter and as an entity carried by a waiter]
+-> counter storage of food
+-> waiter building and destroying
+-> interaction detection [x], creation and processing
+
+
+-> when a customer sits at a table they make a request [they transition to a waiting state], and waits for up to 2 minutes
+   -> this is a state change and a ui indication to the player to respond
+
+-> within that time, the player must respond and serve the customer their request
+-> use the player / waiter dogs to serve the food 
+   -> must first navigate to the counter
+   -> upon going to the counter an interaction is performed to pick up the food
+      -> can detect the interaction through the handshake
+      -> processing the interaction in this case would do the following:
+         -> pop the food from the counter stack
+         -> create it as an entity at the dog food offset position, have it tied to the dog's movmenet
+      
+   -> the dog must then be directed to the table, upon reaching the table, they place the food down
+      -> maintain the food as an entity in the game,
+      -> it must be placed at the food_table_offset
+      -> once placed, the customer must be notified in some way to start eating, the table and its interactable component 
+      could be that link
+   -> so the dog interaction with a station depends on the following:
+      -> the type of dog and type of station
+      -> the state of the dog
+
+   -> when the food is placed, the customer eats for a set duration [10-20s]
+   -> after, they leave [ should map a cafe exit tunnel like the entrance]
+
+
+customer states [entering, waiting, eating, leaving]
+waiter states [idle, serving, clearing]

--- a/src/engine/components/component.h
+++ b/src/engine/components/component.h
@@ -69,19 +69,32 @@ private:
 
 
 // for the table, the waiter, and the counter and the kitchen station
-class food_component {
+class storage_component {
   // ? current idea for the storage component is for stations to store food,
   // ? tables to store foood
   // ? and dishwasher to store plates
   public:
-    ~food_component() = default;
-    food_component() = default;
-    food_component(const food_component& other) = default;
-    food_component(food_component&& other) = default;
+    ~storage_component() = default;
+    storage_component(size_t capacity)
+    : capacity_(capacity), item_ids_(){}
+    storage_component(const storage_component& other) = default;
+    storage_component(storage_component&& other) = default;
 
-    food_component& operator=(const food_component& other) = default;
-    food_component& operator=(food_component&& other) = default;
+    storage_component& operator=(const storage_component& other) = default;
+    storage_component& operator=(storage_component&& other) = default;
+
+    bool empty() const;
+    size_t size() const;
+    size_t capacity() const;
+    bool full() const;
+    size_t at(size_t index) const;
+    // the top of the stack - precondition: !empty()
+    size_t front() const;
+    // rejects (returns false) once size() == capacity_
+    bool push(size_t item_id);
   private:
+    size_t capacity_;
+    std::vector<size_t> item_ids_;
 };
 class interactable_component {
 public:
@@ -391,7 +404,6 @@ private:
 // * which would blur the storage layer into the data layer.
 extern component_manager<components::collision_component> collision_manager_;
 extern component_manager<components::key_input_component> control_manager_;
-extern component_manager<components::food_component> food_manager_;
 extern component_manager<components::interactable_component> interactable_manager_;
 extern component_manager<components::interactor_component> interactor_manager_;
 extern component_manager<components::mouse_input_component> mouse_input_manager_;
@@ -400,6 +412,7 @@ extern component_manager<components::position_component> positional_manager_;
 extern component_manager<components::renderable_component> renderable_manager_;
 extern component_manager<components::selectable_component> selectable_manager_;
 extern component_manager<components::state_machine_component> state_machine_manager_;
+extern component_manager<components::storage_component> storage_manager_;
 } // namespace component_managers
 
 namespace component_builders{
@@ -422,8 +435,8 @@ namespace component_builders{
     components::mouse_input_component build_mouse_input_component(std::vector<game_config::input>& inputs);
     components::state_machine_component::state_component build_state();
     components::state_machine_component build_state_machine_component(std::vector<components::state_machine_component::state_component>& state_components);
-    components::food_component build_food_component();
     components::selectable_component build_selectable_component(size_t kind);
+    components::storage_component build_storage_component(size_t capacity);
 }
 // thin forwarders to the right manager; defined in component_helpers.cpp
 namespace component_helpers{
@@ -436,8 +449,8 @@ namespace component_helpers{
     void register_key_input_component(size_t entity_id, components::key_input_component component);
     void register_mouse_input_component(size_t entity_id, components::mouse_input_component component);
     void register_state_machine_component(size_t entity_id, components::state_machine_component component);
-    void register_food_component(size_t entity_id, components::food_component component);
     void register_selectable_component(size_t entity_id, components::selectable_component component);
+    void register_storage_component(size_t entity_id, components::storage_component component);
 
     void add_positional_component(size_t entity_id, Vector2 position);
     void add_movement_component(size_t entity_id, Vector2 move_speed,
@@ -455,8 +468,8 @@ namespace component_helpers{
     void add_mouse_input_component(size_t entity_id, std::vector<game_config::input>& inputs);
     void add_state_machine_component(size_t entity_id,
         std::vector<components::state_machine_component::state_component>& state_components);
-    void add_food_component(size_t entity_id);
     void add_selectable_component(size_t entity_id, size_t kind);
+    void add_storage_component(size_t entity_id, size_t capacity);
 
     void create_offset_position_list(Rectangle box, std::array<std::optional<Vector2>, DIRECTIONS>& positions);
     bool is_mouse_positioned(size_t entity_id);
@@ -471,8 +484,8 @@ namespace component_helpers{
     void unregister_key_input_component(size_t entity_id);
     void unregister_mouse_input_component(size_t entity_id);
     void unregister_state_machine_component(size_t entity_id);
-    void unregister_food_component(size_t entity_id);
     void unregister_selectable_component(size_t entity_id);
+    void unregister_storage_component(size_t entity_id);
     void unregister_all_components(size_t entity_id);
 
     size_t num_registered_components(size_t entity_id);

--- a/src/engine/components/component.h
+++ b/src/engine/components/component.h
@@ -15,6 +15,7 @@
 #include "events.h"
 #include "events_interface.h"
 #include "hitbox.h"
+#include "item_stack.hpp"
 #include "path.h"
 #include "raylib.h"
 #include "raymath.h"
@@ -75,8 +76,8 @@ class storage_component {
   // ? and dishwasher to store plates
   public:
     ~storage_component() = default;
-    storage_component(size_t capacity)
-    : capacity_(capacity), item_ids_(){}
+    storage_component(item_stack::item_stack items)
+    :items_(items){}
     storage_component(const storage_component& other) = default;
     storage_component(storage_component&& other) = default;
 
@@ -85,16 +86,11 @@ class storage_component {
 
     bool empty() const;
     size_t size() const;
-    size_t capacity() const;
-    bool full() const;
-    size_t at(size_t index) const;
-    // the top of the stack - precondition: !empty()
-    size_t front() const;
-    // rejects (returns false) once size() == capacity_
-    bool push(size_t item_id);
+    item_stack::item& head();
+    size_t take();
+    void place(size_t item_id);
   private:
-    size_t capacity_;
-    std::vector<size_t> item_ids_;
+    item_stack::item_stack items_;
 };
 class interactable_component {
 public:

--- a/src/engine/components/component_accessors.cpp
+++ b/src/engine/components/component_accessors.cpp
@@ -221,27 +221,23 @@ void components::selectable_component::unselect(){
 
 // ---------------- storage_component ----------------
 bool components::storage_component::empty() const{
-    return item_ids_.empty();
+    return items_.empty();
 }
 size_t components::storage_component::size() const{
-    return item_ids_.size();
+    return items_.size();
 }
-size_t components::storage_component::capacity() const{
-    return capacity_;
+item_stack::item& components::storage_component::head(){
+    return items_.head();
 }
-bool components::storage_component::full() const{
-    return item_ids_.size() >= capacity_;
-}
-size_t components::storage_component::at(size_t index) const{
-    return item_ids_.at(index);
-}
-size_t components::storage_component::front() const{
-    return item_ids_.front();
-}
-bool components::storage_component::push(size_t item_id){
-    if(full()){
-        return false;
+size_t components::storage_component::take(){
+    auto h = head();
+    auto h_id = h.get_id();
+    --h;
+    if(h.get_count() == 0){
+        items_.pop();
     }
-    item_ids_.push_back(item_id);
-    return true;
+    return h_id;
+}
+void components::storage_component::place(size_t item_id){
+    items_.push(item_id);
 }

--- a/src/engine/components/component_accessors.cpp
+++ b/src/engine/components/component_accessors.cpp
@@ -218,3 +218,30 @@ void components::selectable_component::select(){
 void components::selectable_component::unselect(){
     is_selected_ = false;
 }
+
+// ---------------- storage_component ----------------
+bool components::storage_component::empty() const{
+    return item_ids_.empty();
+}
+size_t components::storage_component::size() const{
+    return item_ids_.size();
+}
+size_t components::storage_component::capacity() const{
+    return capacity_;
+}
+bool components::storage_component::full() const{
+    return item_ids_.size() >= capacity_;
+}
+size_t components::storage_component::at(size_t index) const{
+    return item_ids_.at(index);
+}
+size_t components::storage_component::front() const{
+    return item_ids_.front();
+}
+bool components::storage_component::push(size_t item_id){
+    if(full()){
+        return false;
+    }
+    item_ids_.push_back(item_id);
+    return true;
+}

--- a/src/engine/components/component_builders.cpp
+++ b/src/engine/components/component_builders.cpp
@@ -40,9 +40,9 @@ components::state_machine_component component_builders::build_state_machine_comp
     (void) state_components;
     return components::state_machine_component();
 }
-components::food_component component_builders::build_food_component(){
-    return components::food_component();
-}
 components::selectable_component component_builders::build_selectable_component(size_t kind){
     return components::selectable_component(kind);
+}
+components::storage_component component_builders::build_storage_component(size_t capacity){
+    return components::storage_component(capacity);
 }

--- a/src/engine/components/component_helpers.cpp
+++ b/src/engine/components/component_helpers.cpp
@@ -27,11 +27,11 @@ void component_helpers::register_mouse_input_component(size_t entity_id, compone
 void component_helpers::register_state_machine_component(size_t entity_id, components::state_machine_component component){
     component_managers::state_machine_manager_.register_component(entity_id, std::move(component));
 }
-void component_helpers::register_food_component(size_t entity_id, components::food_component component){
-    component_managers::food_manager_.register_component(entity_id, std::move(component));
-}
 void component_helpers::register_selectable_component(size_t entity_id, components::selectable_component component){
     component_managers::selectable_manager_.register_component(entity_id, std::move(component));
+}
+void component_helpers::register_storage_component(size_t entity_id, components::storage_component component){
+    component_managers::storage_manager_.register_component(entity_id, std::move(component));
 }
 
 void component_helpers::add_positional_component(size_t entity_id, Vector2 position){
@@ -76,12 +76,13 @@ void component_helpers::add_state_machine_component(size_t entity_id,
     register_state_machine_component(entity_id,
         component_builders::build_state_machine_component(state_components));
 }
-void component_helpers::add_food_component(size_t entity_id){
-    register_food_component(entity_id, component_builders::build_food_component());
-}
 void component_helpers::add_selectable_component(size_t entity_id, size_t kind){
     register_selectable_component(entity_id,
         component_builders::build_selectable_component(kind));
+}
+void component_helpers::add_storage_component(size_t entity_id, size_t capacity){
+    register_storage_component(entity_id,
+        component_builders::build_storage_component(capacity));
 }
 
 void component_helpers::create_offset_position_list(Rectangle box, std::array<std::optional<Vector2>, DIRECTIONS>& positions){
@@ -175,11 +176,11 @@ void component_helpers::unregister_mouse_input_component(size_t entity_id){
 void component_helpers::unregister_state_machine_component(size_t entity_id){
     component_managers::state_machine_manager_.unregister_component(entity_id);
 }
-void component_helpers::unregister_food_component(size_t entity_id){
-    component_managers::food_manager_.unregister_component(entity_id);
-}
 void component_helpers::unregister_selectable_component(size_t entity_id){
     component_managers::selectable_manager_.unregister_component(entity_id);
+}
+void component_helpers::unregister_storage_component(size_t entity_id){
+    component_managers::storage_manager_.unregister_component(entity_id);
 }
 
 // blanket teardown - erase on a missing key is a no-op, so this is correct
@@ -194,8 +195,8 @@ void component_helpers::unregister_all_components(size_t entity_id){
     unregister_key_input_component(entity_id);
     unregister_mouse_input_component(entity_id);
     unregister_state_machine_component(entity_id);
-    unregister_food_component(entity_id);
     unregister_selectable_component(entity_id);
+    unregister_storage_component(entity_id);
 }
 
 // total components registered across every manager
@@ -210,8 +211,8 @@ size_t component_helpers::num_registered_components(size_t entity_id){
     count += component_managers::control_manager_.get_component(entity_id) != nullptr ? 1u : 0u;
     count += component_managers::mouse_input_manager_.get_component(entity_id) != nullptr ? 1u : 0u;
     count += component_managers::state_machine_manager_.get_component(entity_id) != nullptr ? 1u : 0u;
-    count += component_managers::food_manager_.get_component(entity_id) != nullptr ? 1u : 0u;
     count += component_managers::selectable_manager_.get_component(entity_id) != nullptr ? 1u : 0u;
+    count += component_managers::storage_manager_.get_component(entity_id) != nullptr ? 1u : 0u;
     return count;
 }
 
@@ -226,6 +227,6 @@ void component_helpers::clear_all_components(){
     component_managers::control_manager_.clear();
     component_managers::mouse_input_manager_.clear();
     component_managers::state_machine_manager_.clear();
-    component_managers::food_manager_.clear();
     component_managers::selectable_manager_.clear();
+    component_managers::storage_manager_.clear();
 }

--- a/src/engine/components/component_managers.cpp
+++ b/src/engine/components/component_managers.cpp
@@ -3,7 +3,6 @@
 namespace component_managers {
 component_manager<components::collision_component> collision_manager_;
 component_manager<components::key_input_component> control_manager_;
-component_manager<components::food_component> food_manager_;
 component_manager<components::interactable_component> interactable_manager_;
 component_manager<components::interactor_component> interactor_manager_;
 component_manager<components::mouse_input_component> mouse_input_manager_;
@@ -12,4 +11,5 @@ component_manager<components::position_component> positional_manager_;
 component_manager<components::renderable_component> renderable_manager_;
 component_manager<components::selectable_component> selectable_manager_;
 component_manager<components::state_machine_component> state_machine_manager_;
+component_manager<components::storage_component> storage_manager_;
 } // namespace component_managers

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -272,6 +272,10 @@ namespace entity_config{
         dining_table = 0,
         tables_size
     };
+    enum counters{
+        food_counter = 0,
+        counters_size
+    };
 
     // file paths
     inline const char* background_path = "../sprites/background.png" ;
@@ -312,6 +316,7 @@ namespace entity_config{
     inline const char* dog_painting_decoration_path = "../sprites/one-dog-goes-this-way.png";
 
     inline const char* dining_table_station_path = "../sprtes/dining-table.png";
+    inline const char* food_counter_station_path = "";
     // NPC dog sprite art pending.
     // inline const char* npc_dog_left_path = "../sprites/npc_dog_left.png";
     // inline const char* npc_dog_right_path = "../sprites/npc_dog_right.png";

--- a/src/engine/game.cpp
+++ b/src/engine/game.cpp
@@ -35,10 +35,8 @@ void game::game::init(){
     }, level_config::dogs);
     debug::log("[game::init, built mack] id " + std::to_string(mack_id));
 
-    auto counter_id = lifespan_.create([](size_t id) -> void {
-        ecs_entities::build_counter(id, Vector2 {level_config::edge_weight * 12, level_config::edge_weight * 4});
-    }, level_config::draw_layers::decoration);
     //* ----------------------------------------------------------------------------------------------------------------------
+    lifespan_.create_counter(entity_config::counters::food_counter, Vector2{level_config::edge_weight * 12, level_config::edge_weight * 4});
     lifespan_.create_table(entity_config::tables::dining_table, Vector2{level_config::edge_weight * 6, level_config::edge_weight * 6});
     //* ----------------------------------------------------------------------------------------------------------------------
 

--- a/src/engine/structures/item_stack.cpp
+++ b/src/engine/structures/item_stack.cpp
@@ -1,0 +1,64 @@
+#include "item_stack.hpp"
+
+size_t item_stack::item::get_id(){
+    return item_id_;
+}
+std::uint8_t item_stack::item::get_count(){
+    return count_;
+}
+
+// size is the number of item objects - does not consider count 
+size_t item_stack::item_stack::size(){
+    return items_.size();
+}
+// total is the number of total items - does consider count
+size_t item_stack::item_stack::total(){
+    size_t count = 0;
+    for(auto item : items_){
+        count += item.get_count();
+    }
+    return count;
+}
+bool item_stack::item_stack::empty(){
+    return size() == 0;
+}
+// ? i think you've got these mixed up, they should be accessing the back not the front
+item_stack::item& item_stack::item_stack::head(){
+    return items_.back();
+}
+void item_stack::item_stack::pop(){
+    if(items_.begin() != items_.end()){
+        auto end = items_.end();
+        end = std::prev(items_.end(), 1);
+    }
+}
+void item_stack::item_stack::push(item item){
+   if(empty()){
+    items_.push_back(item);
+   }
+   else{
+    auto h = head();
+    if(h == item){
+        increment(h);
+    }
+    else{
+
+    }
+   }
+}
+// * is a stack so these two only interact with the head of the list
+void item_stack::item_stack::take(){
+    decrement(head());
+}
+
+void item_stack::item_stack::place(item item){
+    increment(item);
+}
+
+//  TODO implement 26 / 8 / 26
+void item_stack::item_stack::increment(item item){
+    (void) item;
+}
+void item_stack::item_stack::decrement(item item){
+    (void) item;
+}

--- a/src/engine/structures/item_stack.cpp
+++ b/src/engine/structures/item_stack.cpp
@@ -8,18 +8,18 @@ std::uint8_t item_stack::item::get_count(){
 }
 
 // size is the number of item objects - does not consider count 
-size_t item_stack::item_stack::size(){
+size_t item_stack::item_stack::size() const{
     return items_.size();
 }
 // total is the number of total items - does consider count
-size_t item_stack::item_stack::total(){
+size_t item_stack::item_stack::total() const{
     size_t count = 0;
     for(auto item : items_){
         count += item.get_count();
     }
     return count;
 }
-bool item_stack::item_stack::empty(){
+bool item_stack::item_stack::empty() const { 
     return size() == 0;
 }
 // ? i think you've got these mixed up, they should be accessing the back not the front
@@ -32,33 +32,29 @@ void item_stack::item_stack::pop(){
         end = std::prev(items_.end(), 1);
     }
 }
-void item_stack::item_stack::push(item item){
+void item_stack::item_stack::push(size_t item_id){
    if(empty()){
-    items_.push_back(item);
+        items_.push_back(item(item_id));
    }
    else{
     auto h = head();
-    if(h == item){
-        increment(h);
+    if(h.get_id() == item_id and h.get_count() < STACK_LIMIT){
+        ++h;
     }
     else{
-
+        items_.push_back(item(item_id));
     }
    }
 }
-// * is a stack so these two only interact with the head of the list
-void item_stack::item_stack::take(){
-    decrement(head());
+size_t item_stack::item_stack::take(){
+    auto h = head();
+    auto h_id = h.get_id();
+    --h;
+    if(h.get_count() == 0){
+        pop();
+    }
+    return h_id;
 }
-
-void item_stack::item_stack::place(item item){
-    increment(item);
-}
-
-//  TODO implement 26 / 8 / 26
-void item_stack::item_stack::increment(item item){
-    (void) item;
-}
-void item_stack::item_stack::decrement(item item){
-    (void) item;
+void item_stack::item_stack::place(size_t item_id){
+    push(item_id);
 }

--- a/src/engine/structures/item_stack.hpp
+++ b/src/engine/structures/item_stack.hpp
@@ -1,0 +1,90 @@
+#ifndef ITEM_STACK_H
+#define ITEM_STACK_H
+#include <cstdint>
+#include <algorithm>
+#include <vector>
+// multi purpose item stack, usable for food counters and displaying inventory
+// operates like a stack, under the hood uses an array, with a stack limit
+#define STACK_LIMIT 64 // because [unint8] 
+namespace item_stack{
+    class item{
+        public:
+            ~item();
+            item(size_t item_id, std::uint8_t count = 1)
+            :item_id_(item_id), count_(count){};
+
+            item(const item& other) = default;
+            item(item&& other) = default;
+
+            item& operator=(const item& other) = default;
+            item& operator=(item&& other) = default;
+            item& operator++(){
+                ++count_;
+                return *this;
+            }
+            item& operator++(int){
+                auto temp = *this;
+                ++count_;
+                return temp;
+            }
+            item& operator--(){
+                --count_;
+                return *this;
+            }
+            item& operator--(int){
+                auto temp = *this;
+                --count_;
+                return temp;
+            }
+            friend bool operator==(const item& a, const item& b){
+                // TODO 26 / 08 actually implment
+                return true;
+            }
+            size_t get_id();
+            std::uint8_t get_count();
+        private:
+            size_t item_id_;
+            std::uint8_t count_;
+    };
+    class item_stack{
+        public:
+            ~item_stack() = default;
+            item_stack()
+            :items_({}) {}
+            
+            item_stack(std::vector<item>& items)
+            :items_(items){}
+
+            item_stack(std::vector<size_t> item_ids)
+            : item_stack(){
+                for(size_t& id : item_ids){
+                    items_.push_back(item(id));
+                }
+            }
+            item_stack(const item_stack& other);
+            item_stack(item_stack&& other);
+
+            item_stack& operator=(const item_stack& other) = default;
+            item_stack& operator=(item_stack&& other) = default;
+
+            // size is the number of item objects - does not consider count 
+            size_t size();
+            // total is the number of total items - does consider count
+            size_t total();
+            bool empty();
+            item& head();
+            void pop();
+            void push(item item);
+
+            // * is a stack so these two only interact with the head of the list
+            void take();
+            void place(item item);
+
+            void increment(item item);
+            void decrement(item item);
+        private:
+            std::vector<item> items_;
+    };
+    
+}
+#endif

--- a/src/engine/structures/item_stack.hpp
+++ b/src/engine/structures/item_stack.hpp
@@ -68,20 +68,17 @@ namespace item_stack{
             item_stack& operator=(item_stack&& other) = default;
 
             // size is the number of item objects - does not consider count 
-            size_t size();
+            size_t size() const;
             // total is the number of total items - does consider count
-            size_t total();
-            bool empty();
+            size_t total() const;
+            bool empty() const;
             item& head();
             void pop();
-            void push(item item);
+            void push(size_t item_id);
 
             // * is a stack so these two only interact with the head of the list
-            void take();
-            void place(item item);
-
-            void increment(item item);
-            void decrement(item item);
+            size_t take();
+            void place(size_t item_id);
         private:
             std::vector<item> items_;
     };

--- a/src/engine/systems/entity_lifespan_system.cpp
+++ b/src/engine/systems/entity_lifespan_system.cpp
@@ -48,3 +48,12 @@ void systems::entity_lifespan_system::destroy_table(size_t id){
     destroy(id);
     npc_system::get_instance().unregister_table(id);
 }
+
+size_t systems::entity_lifespan_system::create_counter(size_t counter, Vector2 position){
+    auto id = create([this](size_t id, size_t counter, Vector2 position) -> void{ station_factory_.build_counter(id, counter, position); },
+        counter, position, level_config::draw_layers::stations);
+    return id;
+}
+void systems::entity_lifespan_system::destroy_counter(size_t id){
+    destroy(id);
+}

--- a/src/engine/systems/system.h
+++ b/src/engine/systems/system.h
@@ -175,6 +175,9 @@ namespace systems{
 
             size_t create_table(size_t table, Vector2 position);
             void destroy_table(size_t id);
+
+            size_t create_counter(size_t counter, Vector2 position);
+            void destroy_counter(size_t id);
             void destroy(size_t entity_id);
             void update(float delta);
             // teardown between test scenarios - the singleton outlives them

--- a/src/entities/ecs_builders.cpp
+++ b/src/entities/ecs_builders.cpp
@@ -168,14 +168,17 @@ void ecs_entities::build_station(size_t id, Vector2 position,
     component_helpers::create_offset_position_list(box, offsets);
     component_helpers::add_interactable_component(id, station_reach, offsets);
 }
-    void ecs_entities::build_counter(size_t id, Vector2 position){
+    void ecs_entities::build_counter(size_t id, Vector2 position, sprite::sprite sprite){
         build_station(id, position,
-            sprite_builders::build_food_counter_sprite(),
+            sprite,
             hitbox_builders::build_food_counter_hitbox(position),
             entity_config::station_reach,
             {entity_config::station_slot_left, entity_config::station_slot_right,
              entity_config::station_slot_up, entity_config::station_slot_down});
     }
+        void ecs_entities::build_food_counter(size_t id, Vector2 position){
+            build_counter(id, position, sprite_builders::build_food_counter_sprite());
+        }
     void ecs_entities::build_table(size_t id, Vector2 position, sprite::sprite sprite){
         build_station(id, position,
             sprite,

--- a/src/entities/entity.h
+++ b/src/entities/entity.h
@@ -129,7 +129,8 @@ namespace ecs_entities {
     void build_station(size_t id, Vector2 position,
         sprite::sprite station_sprite, hitbox::hitbox station_hitbox,
         float station_reach, std::array<std::optional<Vector2>, DIRECTIONS> slot_offsets);
-        void build_counter(size_t id, Vector2 position);
+        void build_counter(size_t id, Vector2 position, sprite::sprite counter_sprite);
+            void build_food_counter(size_t id, Vector2 position);
         void build_table(size_t id, Vector2 position, sprite::sprite table_sprite);
             void build_dining_table(size_t id, Vector2 position);
         void build_dishwasher(size_t id, Vector2 position);

--- a/src/entities/factories/factories.hpp
+++ b/src/entities/factories/factories.hpp
@@ -74,6 +74,8 @@ namespace factories{
             station_factory()
             :table_builders_({
                 [](size_t id, Vector2 position) -> void{ecs_entities::build_dining_table(id, position);},
+            }), counter_builders_({
+                [](size_t id, Vector2 position) -> void{ecs_entities::build_food_counter(id, position);},
             }){
 
             }
@@ -81,12 +83,14 @@ namespace factories{
             station_factory(station_factory&& other) = default;
             station_factory& operator=(const station_factory& other) = default;
             station_factory& operator=(station_factory&& other) = default;
-            
+
             void build_station(size_t id, Vector2 position);
             void build_table(size_t table, size_t entity_id, Vector2 position);
+            void build_counter(size_t counter, size_t entity_id, Vector2 position);
             void build_stove(size_t id, Vector2 position);
         private:
             std::array<std::function<void(size_t, Vector2)>, entity_config::tables_size> table_builders_;
+            std::array<std::function<void(size_t, Vector2)>, entity_config::counters_size> counter_builders_;
     };
 }
 #endif

--- a/src/entities/factories/station_factory.cpp
+++ b/src/entities/factories/station_factory.cpp
@@ -8,6 +8,10 @@ void factories::station_factory::build_table(size_t table, size_t entity_id, Vec
     auto table_builder = table_builders_[table];
     table_builder(entity_id, position);
 }
+void factories::station_factory::build_counter(size_t counter, size_t entity_id, Vector2 position){
+    auto counter_builder = counter_builders_[counter];
+    counter_builder(entity_id, position);
+}
 void factories::station_factory::build_stove(size_t id, Vector2 position){
     (void) id;
     (void) position;

--- a/src/rendering/sprite_builders.cpp
+++ b/src/rendering/sprite_builders.cpp
@@ -51,9 +51,9 @@ sprite::sprite sprite_builders::build_table_sprite(){
     sprite::sprite sprite_builders::build_dining_table_sprite(){
         return build_decoration_sprite(textures::dining_table, entity_config::dining_table_station_path, entity_config::dining_table_attributes);
     }
-sprite::sprite sprite_builders::build_food_counter_sprite(){
-    return build_test_decoration_sprite(entity_config::food_counter_attributes, BLUE);
-}
+    sprite::sprite sprite_builders::build_food_counter_sprite(){
+        return build_decoration_sprite(textures::food_counter, entity_config::food_counter_station_path, entity_config::food_counter_attributes);
+    }
 sprite::sprite sprite_builders::build_dishwasher_sprite(){
     return build_test_decoration_sprite(entity_config::dishwasher_attributes, PURPLE);
 }

--- a/src/rendering/texture.h
+++ b/src/rendering/texture.h
@@ -46,6 +46,7 @@ namespace textures{
         // npc_dog_head_left = 22,
         // npc_dog_head_right = 23,
         dining_table,
+        food_counter,
         background,
         size
         // and so on

--- a/tests/ecs_test_game.cpp
+++ b/tests/ecs_test_game.cpp
@@ -93,7 +93,7 @@ namespace testing{
 
     size_t ecs_test_game::create_food_counter(Vector2 position, size_t layer){
         return lifespan_.create([position](size_t id){
-            ecs_entities::build_counter(id, position);
+            ecs_entities::build_food_counter(id, position);
         }, layer);
     }
 
@@ -297,8 +297,8 @@ namespace testing{
              + component_managers::control_manager_.size()
              + component_managers::mouse_input_manager_.size()
              + component_managers::state_machine_manager_.size()
-             + component_managers::food_manager_.size()
-             + component_managers::selectable_manager_.size();
+             + component_managers::selectable_manager_.size()
+             + component_managers::storage_manager_.size();
     }
 
 } // namespace testing


### PR DESCRIPTION
- setup counters to store food
- define an item stack for storing entities in a way that only provides viewing access to the top most entity,
- define builders for counters and waiters
- setup waiter idling state and waiter controlling like player dogs
- 